### PR TITLE
Add Claude model support alongside OpenAI

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -38,8 +38,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          # Optional: update to a model of your choice from https://platform.openai.com/docs/models
-          OPENAI_MODEL: "gpt-5"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Pick your model: claude-* models use your ANTHROPIC_API_KEY, anything
+          # else uses your OPENAI_API_KEY. You only need the secret for the
+          # provider you choose.
+          # Claude models: https://platform.claude.com/docs/en/about-claude/models/overview
+          # OpenAI models: https://platform.openai.com/docs/models
+          MODEL: "gpt-5"
 
       - name: Comment on Pull Request
         run: |

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -19,8 +19,8 @@ jobs:
         run: |
           git clone https://github.com/codylabs/cody-code-reviewer.git
           cd cody-code-reviewer
-          # Pin to a specific release commit to ensure stability https://github.com/codylabs/cody-code-reviewer/releases/tag/v1.2.0
-          git checkout 2eee062e2ba9918fbfd28d218a9d2b095e99d57e
+          # Pin to a specific release commit to ensure stability https://github.com/codylabs/cody-code-reviewer/releases/tag/v1.3.0
+          git checkout 42800f56034b775ea5dedfcdf44882213e17a70c
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ jobs:
         run: |
           git clone https://github.com/codylabs/cody-code-reviewer.git
           cd cody-code-reviewer
-          # Pin to a specific release commit to ensure stability https://github.com/codylabs/cody-code-reviewer/releases/tag/v1.2.0
-          git checkout 2eee062e2ba9918fbfd28d218a9d2b095e99d57e
+          # Pin to a specific release commit to ensure stability https://github.com/codylabs/cody-code-reviewer/releases/tag/v1.3.0
+          git checkout 42800f56034b775ea5dedfcdf44882213e17a70c
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 ## About
 
-Cody will automatically summarize and code review your changes on every pull request using Open AI models.
+Cody will automatically summarize and code review your changes on every pull request using OpenAI or Anthropic Claude models.
 
-Note that an Open AI API key is required.
+Note that an OpenAI or Anthropic API key is required, depending on the model you choose.
 
 Read more at [https://codylabs.pages.dev/](https://codylabs.pages.dev/)
 
 ## Installation
 
-Installation is as simple as adding your Open AI API key, and adding a Github Actions workflow file to your repo.
+Installation is as simple as adding your AI provider API key, and adding a Github Actions workflow file to your repo.
 
-1. Add your OPENAI_API_KEY as a GitHub repo secret via Settings > Actions > Secrets and variables > New repository secret.
+1. Add your OPENAI_API_KEY (or ANTHROPIC_API_KEY for Claude models) as a GitHub repo secret via Settings > Actions > Secrets and variables > New repository secret.
 
 <img src="openai.png" alt="Open API Api Key" width="500px">
 
@@ -65,8 +65,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          # Optional: update to a model of your choice from https://platform.openai.com/docs/models
-          OPENAI_MODEL: "gpt-5"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Pick your model: claude-* models use your ANTHROPIC_API_KEY, anything
+          # else uses your OPENAI_API_KEY. You only need the secret for the
+          # provider you choose.
+          # Claude models: https://platform.claude.com/docs/en/about-claude/models/overview
+          # OpenAI models: https://platform.openai.com/docs/models
+          MODEL: "gpt-5"
 
       - name: Comment on Pull Request
         run: |
@@ -77,6 +82,39 @@ jobs:
 ```
 
 3. Commit your code, create a pull request and watch Cody in action!
+
+## Using Claude models
+
+Cody works with Anthropic's Claude models as well as OpenAI's. To review with Claude:
+
+1. Add ANTHROPIC_API_KEY as a repo secret (create a key at https://platform.claude.com/).
+2. Set MODEL to a Claude model in the "Run Code Review Model" step of your workflow:
+
+```
+      - name: Run Code Review Model
+        run: |
+          python src/review_pull_request.py ${{ github.event.pull_request.number }} ${{ github.repository }} > ${{ github.workspace }}/output.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MODEL: "claude-opus-4-8"
+```
+
+Any model name starting with claude- is sent to Anthropic; anything else goes to OpenAI, so you only need the API key for the provider you pick.
+
+| Model | Best for |
+| --- | --- |
+| claude-opus-4-8 | The most capable reviews — recommended |
+| claude-sonnet-5 | Near-Opus quality at lower cost |
+| claude-haiku-4-5 | Fastest and cheapest |
+
+The full model list is at https://platform.claude.com/docs/en/about-claude/models/overview.
+
+## GitLab & Azure DevOps (Cody Pro)
+
+Cody Pro brings the same AI code reviews to GitLab merge requests and Azure DevOps pull requests, with ready-made pipeline templates for both platforms and support for the same OpenAI and Claude models. It's a one-time purchase:
+
+**[Get Cody Pro on Gumroad](https://codylabs.gumroad.com/l/cody-pro)**
 
 <img src="cody_review_2.png" alt="PR Code Review Image" width="640px">
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Cody AI Code Reviewer - Powered by OpenAI"
-description: "Run AI code reviews on pull requests using your Open AI API key"
+description: "Run AI code reviews on pull requests using your OpenAI or Anthropic Claude API key"
 inputs:
   pr_number:
     description: "Pull request number"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ python-dotenv
 pytest
 PyGithub
 openai
+anthropic
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -4,6 +4,9 @@ from dotenv import load_dotenv
 load_dotenv()
 
 OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+ANTHROPIC_API_KEY = os.getenv('ANTHROPIC_API_KEY')
 GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
 DEBUG_MODE = os.getenv('DEBUG_MODE', 'false').lower() == 'true'
-OPENAI_MODEL = os.getenv('OPENAI_MODEL', 'gpt-5')
+# MODEL picks the reviewer model; claude-* models use Anthropic, anything else OpenAI.
+# OPENAI_MODEL is honoured for backwards compatibility with existing workflows.
+MODEL = os.getenv('MODEL') or os.getenv('OPENAI_MODEL') or 'gpt-5'

--- a/src/model.py
+++ b/src/model.py
@@ -1,27 +1,40 @@
 import time
 import logging
-from openai import OpenAI
-import openai
 import config
 
 logging.basicConfig(level=logging.DEBUG if config.DEBUG_MODE else logging.INFO)
 
-OPENAI_API_KEY = config.OPENAI_API_KEY
-OPENAI_MODEL = config.OPENAI_MODEL
+MODEL = config.MODEL
 
-client = OpenAI(
-    api_key=OPENAI_API_KEY,
-)
+SYSTEM_PROMPT = "You are a senior software engineer at Google reviewing a pull request."
+
+
+def query_model(prompt: str, retries=3, base_delay=1.0) -> str:
+    """Send a prompt to the configured model provider and return the response.
+
+    Models named claude-* are sent to the Anthropic API; everything else goes to OpenAI.
+    """
+    if MODEL.lower().startswith("claude"):
+        return query_claude(prompt, retries=retries, base_delay=base_delay)
+    return query_openai(prompt, retries=retries, base_delay=base_delay)
+
 
 def query_openai(prompt: str, retries=3, base_delay=1.0) -> str:
     """Send a prompt to the OpenAI API and return the response or an error message, with retry logic."""
+    from openai import OpenAI
+    import openai
+
+    client = OpenAI(
+        api_key=config.OPENAI_API_KEY,
+    )
+
     attempt = 0
     while attempt < retries:
         try:
             completion = client.chat.completions.create(
-                model=OPENAI_MODEL,
+                model=MODEL,
                 messages=[
-                    {"role": "system", "content": "You are a senior software engineer at Google reviewing a pull request."},
+                    {"role": "system", "content": SYSTEM_PROMPT},
                     {"role": "user", "content": prompt}
                 ]
             )
@@ -42,5 +55,48 @@ def query_openai(prompt: str, retries=3, base_delay=1.0) -> str:
             attempt += 1
 
     error_message = "Failed to query OpenAI API after several attempts."
+    logging.error(error_message)
+    return error_message
+
+
+def query_claude(prompt: str, retries=3, base_delay=1.0) -> str:
+    """Send a prompt to the Anthropic API and return the response or an error message, with retry logic."""
+    import anthropic
+
+    client = anthropic.Anthropic(
+        api_key=config.ANTHROPIC_API_KEY,
+    )
+
+    attempt = 0
+    while attempt < retries:
+        try:
+            response = client.messages.create(
+                model=MODEL,
+                max_tokens=16000,
+                system=SYSTEM_PROMPT,
+                messages=[
+                    {"role": "user", "content": prompt}
+                ]
+            )
+            text = "".join(block.text for block in response.content if block.type == "text")
+            if text:
+                return text
+            logging.error(f"Claude returned no text on attempt {attempt + 1} (stop_reason: {response.stop_reason})")
+            return f"Claude returned no review (stop_reason: {response.stop_reason})."
+        except anthropic.RateLimitError as rate_error:
+            logging.error(f"Anthropic rate limit on attempt {attempt + 1}: {rate_error}")
+            time.sleep(base_delay * (2 ** (attempt + 1)))
+        except anthropic.APIStatusError as api_error:
+            logging.error(f"Anthropic APIStatusError on attempt {attempt + 1}: {api_error}")
+            time.sleep(base_delay * (2 ** attempt))
+        except Exception as e:
+            logging.error(f"General error on attempt {attempt + 1}: {str(e)}")
+            time.sleep(base_delay * (2 ** attempt))
+            if attempt == retries - 1:
+                logging.critical(f"Final attempt failed with error: {str(e)}")
+        finally:
+            attempt += 1
+
+    error_message = "Failed to query the Anthropic API after several attempts."
     logging.error(error_message)
     return error_message

--- a/src/review_pull_request.py
+++ b/src/review_pull_request.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 from github_client import get_pull_request_data
-from model import query_openai
+from model import query_model
 from typing import Optional
 
 def review_pull_request(repo_name: str, pull_number: int) -> None:
@@ -13,7 +13,7 @@ def review_pull_request(repo_name: str, pull_number: int) -> None:
                 f"Respond in a clear and concise github format with relevant headings (supports markdown) but do not start with ```markdown as it will break the github formatting. Start your reponse with 'AI Code Review by Cody (https://codylabs.pages.dev/)', a summary of the change under the heading 'Summary of Change', and then jump straight into a standard code review under the heading 'Code Review'. Be concise, focus on important aspects such as functionality and security and ignore nitpicks where possible. Provide code suggestions using markdown format."
                 f"Title: {pr_data.title}\nDescription: {pr_data.description}\Changes: {pr_data.diff}"
             )
-            response: Optional[str] = query_openai(prompt)
+            response: Optional[str] = query_model(prompt)
             with open('output.txt', 'w') as file:
                 file.write(response or "No response from OpenAI, please try again in a few minutes.")
     except Exception as e:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,51 @@
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import src.model as model
+
+
+def _claude_response(text):
+    return SimpleNamespace(
+        content=[SimpleNamespace(type="text", text=text)],
+        stop_reason="end_turn",
+    )
+
+
+def test_query_model_routes_claude_models_to_anthropic(monkeypatch):
+    monkeypatch.setattr(model, "MODEL", "claude-opus-4-8")
+    with patch("anthropic.Anthropic") as anthropic_cls:
+        anthropic_cls.return_value.messages.create.return_value = _claude_response("Looks good.")
+
+        assert model.query_model("review this") == "Looks good."
+
+        kwargs = anthropic_cls.return_value.messages.create.call_args.kwargs
+        assert kwargs["model"] == "claude-opus-4-8"
+        assert kwargs["messages"] == [{"role": "user", "content": "review this"}]
+        assert kwargs["system"] == model.SYSTEM_PROMPT
+
+
+def test_query_model_routes_other_models_to_openai(monkeypatch):
+    monkeypatch.setattr(model, "MODEL", "gpt-5")
+    completion = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="LGTM"))]
+    )
+    with patch("openai.OpenAI") as openai_cls:
+        openai_cls.return_value.chat.completions.create.return_value = completion
+
+        assert model.query_model("review this") == "LGTM"
+
+        kwargs = openai_cls.return_value.chat.completions.create.call_args.kwargs
+        assert kwargs["model"] == "gpt-5"
+
+
+def test_query_claude_returns_error_message_after_retries(monkeypatch):
+    monkeypatch.setattr(model, "MODEL", "claude-opus-4-8")
+    monkeypatch.setattr(time, "sleep", lambda *_: None)
+    with patch("anthropic.Anthropic") as anthropic_cls:
+        anthropic_cls.return_value.messages.create.side_effect = Exception("boom")
+
+        result = model.query_claude("review this", retries=2, base_delay=0)
+
+        assert result == "Failed to query the Anthropic API after several attempts."
+        assert anthropic_cls.return_value.messages.create.call_count == 2


### PR DESCRIPTION
## What

- New `query_model()` in `src/model.py` routes `claude-*` model names to the Anthropic API (via the official `anthropic` SDK) and everything else to OpenAI, unchanged.
- Model selection via a new `MODEL` env var; `OPENAI_MODEL` is still honoured, default stays `gpt-5`, so existing workflows are unaffected.
- OpenAI/Anthropic clients are now created lazily inside the query functions — previously `model.py` crashed at import when `OPENAI_API_KEY` was unset, which would have broken Claude-only setups.
- Claude calls use `max_tokens=16000` and no sampling params, so any current Claude model (`claude-opus-4-8`, `claude-sonnet-5`, `claude-haiku-4-5`) works without 400s.
- README: Claude usage section with workflow example + model table; sample workflow gains `ANTHROPIC_API_KEY`/`MODEL`; new Cody Pro (GitLab & Azure DevOps) section.
- Sample workflow pin bumped to the Claude-support commit for the upcoming v1.3.0 release.

## Tests

`PYTHONPATH=src pytest tests/ -m "not integration"` — 3 new unit tests for provider routing and Claude error handling, all passing (mocked SDKs, no network).

## After merging

Merge with a **merge commit** (not squash — the sample pin references `42800f5`), then tag `git tag v1.3.0 42800f56034b775ea5dedfcdf44882213e17a70c && git push origin v1.3.0` and create the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)