### PR TITLE
Centralize Cody setup across product channels

### DIFF
--- a/.github/workflows/channel-health.yml
+++ b/.github/workflows/channel-health.yml
@@ -28,6 +28,11 @@ jobs:
               --silent --show-error --output /dev/null "$url"
           done
 
+          readme="$(curl --fail --location --retry 3 --connect-timeout 10 --max-time 60 \
+            --silent --show-error \
+            https://raw.githubusercontent.com/codylabs/cody-code-reviewer/master/README.md)"
+          grep --fixed-strings --quiet '## Installation' <<< "$readme"
+
           latest_release="$(curl --fail --retry 3 --connect-timeout 10 --max-time 60 --silent --show-error \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/channel-health.yml
+++ b/.github/workflows/channel-health.yml
@@ -1,0 +1,32 @@
+name: Channel health
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 8 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check canonical Cody channels
+        run: |
+          set -euo pipefail
+          for url in \
+            "https://github.com/codylabs/cody-code-reviewer#installation" \
+            "https://github.com/marketplace/actions/cody-ai-code-reviewer-powered-by-openai" \
+            "https://docs.codylabs.uk/" \
+            "https://codylabs.uk/" \
+            "https://codylabs.gumroad.com/l/cody-pro"; do
+            curl --fail --location --retry 3 --silent --show-error --output /dev/null "$url"
+          done
+
+          latest_release="$(curl --fail --silent --show-error \
+            https://api.github.com/repos/codylabs/cody-code-reviewer/releases/latest \
+            | python -c 'import json, sys; print(json.load(sys.stdin)["tag_name"])')"
+          marketplace_page="$(curl --fail --location --silent --show-error \
+            https://github.com/marketplace/actions/cody-ai-code-reviewer-powered-by-openai)"
+          grep --fixed-strings --quiet "$latest_release" <<< "$marketplace_page"

--- a/.github/workflows/channel-health.yml
+++ b/.github/workflows/channel-health.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check canonical Cody channels
         run: |
@@ -21,12 +22,13 @@ jobs:
             "https://docs.codylabs.uk/" \
             "https://codylabs.uk/" \
             "https://codylabs.gumroad.com/l/cody-pro"; do
-            curl --fail --location --retry 3 --silent --show-error --output /dev/null "$url"
+            curl --fail --location --retry 3 --connect-timeout 10 --max-time 60 \
+              --silent --show-error --output /dev/null "$url"
           done
 
-          latest_release="$(curl --fail --silent --show-error \
+          latest_release="$(curl --fail --connect-timeout 10 --max-time 60 --silent --show-error \
             https://api.github.com/repos/codylabs/cody-code-reviewer/releases/latest \
             | python -c 'import json, sys; print(json.load(sys.stdin)["tag_name"])')"
-          marketplace_page="$(curl --fail --location --silent --show-error \
+          marketplace_page="$(curl --fail --location --connect-timeout 10 --max-time 60 --silent --show-error \
             https://github.com/marketplace/actions/cody-ai-code-reviewer-powered-by-openai)"
           grep --fixed-strings --quiet "$latest_release" <<< "$marketplace_page"

--- a/.github/workflows/channel-health.yml
+++ b/.github/workflows/channel-health.yml
@@ -14,6 +14,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check canonical Cody channels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           for url in \
@@ -26,9 +28,11 @@ jobs:
               --silent --show-error --output /dev/null "$url"
           done
 
-          latest_release="$(curl --fail --connect-timeout 10 --max-time 60 --silent --show-error \
+          latest_release="$(curl --fail --retry 3 --connect-timeout 10 --max-time 60 --silent --show-error \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/codylabs/cody-code-reviewer/releases/latest \
             | python -c 'import json, sys; print(json.load(sys.stdin)["tag_name"])')"
-          marketplace_page="$(curl --fail --location --connect-timeout 10 --max-time 60 --silent --show-error \
+          marketplace_page="$(curl --fail --location --retry 3 --connect-timeout 10 --max-time 60 --silent --show-error \
             https://github.com/marketplace/actions/cody-ai-code-reviewer-powered-by-openai)"
           grep --fixed-strings --quiet "$latest_release" <<< "$marketplace_page"

--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -21,3 +21,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.6-sol
+          # To switch to Claude, replace the two lines above with:
+          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # model: claude-opus-4-8

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -43,5 +43,6 @@ jobs:
           fi
 
           git fetch --no-tags --depth=1 origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
-          git tag --force v1 "${RELEASE_TAG}"
+          release_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
+          git tag --force v1 "$release_commit"
           git push --force origin refs/tags/v1

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -1,0 +1,26 @@
+name: Update major release tag
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-v1:
+    if: startsWith(github.event.release.tag_name, 'v1.')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Move v1 to the published release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          git init release-tags
+          cd release-tags
+          git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --no-tags --depth=1 origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          git tag --force v1 "${RELEASE_TAG}"
+          git push --force origin refs/tags/v1

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -43,6 +43,13 @@ jobs:
           fi
 
           git fetch --no-tags --depth=1 origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          expected_v1="$(git ls-remote origin refs/tags/v1 | awk '{print $1}')"
           release_commit="$(git rev-parse "${RELEASE_TAG}^{commit}")"
           git tag --force v1 "$release_commit"
-          git push --force origin refs/tags/v1
+          if [[ -n "$expected_v1" ]]; then
+            git push origin \
+              --force-with-lease="refs/tags/v1:${expected_v1}" \
+              refs/tags/v1
+          else
+            git push origin refs/tags/v1
+          fi

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -7,9 +7,13 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: update-v1-tag
+  cancel-in-progress: false
+
 jobs:
   update-v1:
-    if: startsWith(github.event.release.tag_name, 'v1.')
+    if: ${{ !github.event.release.prerelease && startsWith(github.event.release.tag_name, 'v1.') }}
     runs-on: ubuntu-latest
     steps:
       - name: Move v1 to the published release
@@ -18,9 +22,24 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^v1\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Refusing to update v1 from non-stable tag: $RELEASE_TAG" >&2
+            exit 1
+          fi
+
           git init release-tags
           cd release-tags
           git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          latest_stable="$(git ls-remote --tags --refs origin 'v1.*' \
+            | awk '{sub("refs/tags/", "", $2); print $2}' \
+            | grep -E '^v1\.[0-9]+\.[0-9]+$' \
+            | sort -V \
+            | tail -n 1)"
+          if [[ -n "$latest_stable" && "$latest_stable" != "$RELEASE_TAG" ]]; then
+            echo "Refusing to move v1 backward from $latest_stable to $RELEASE_TAG" >&2
+            exit 1
+          fi
+
           git fetch --no-tags --depth=1 origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
           git tag --force v1 "${RELEASE_TAG}"
           git push --force origin refs/tags/v1

--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -2,7 +2,7 @@ name: Update major release tag
 
 on:
   release:
-    types: [published]
+    types: [published, released]
 
 permissions:
   contents: write
@@ -18,6 +18,7 @@ jobs:
     steps:
       - name: Move v1 to the published release
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
@@ -30,8 +31,9 @@ jobs:
           git init release-tags
           cd release-tags
           git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          latest_stable="$(git ls-remote --tags --refs origin 'v1.*' \
-            | awk '{sub("refs/tags/", "", $2); print $2}' \
+          latest_stable="$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
             | grep -E '^v1\.[0-9]+\.[0-9]+$' \
             | sort -V \
             | tail -n 1)"

--- a/CHANNELS.md
+++ b/CHANNELS.md
@@ -1,0 +1,25 @@
+# Cody channel ownership
+
+This repository is the canonical source for Cody's GitHub installation and
+model-selection instructions. Other public channels should describe the
+product and link here instead of copying workflow YAML or model tables.
+
+| Channel | Canonical responsibility |
+| --- | --- |
+| [GitHub README](https://github.com/codylabs/cody-code-reviewer#installation) | Installation, provider selection, current inputs, and model examples |
+| [GitHub Marketplace](https://github.com/marketplace/actions/cody-ai-code-reviewer-powered-by-openai) | Discoverability and the latest published release |
+| [Cody documentation](https://docs.codylabs.uk/) | Product overview, privacy, and links to GitHub setup |
+| [Cody Labs marketing site](https://codylabs.uk/) | Short product positioning and links to GitHub, Marketplace, docs, and Gumroad |
+| [Cody Pro on Gumroad](https://codylabs.gumroad.com/l/cody-pro) | GitLab/Azure DevOps sales page; detailed setup ships with the product |
+
+## Release checklist
+
+1. Merge a tested change to `master`.
+2. Publish a semantic release such as `v1.3.2`.
+3. Confirm the `v1` tag moved to that release; the release workflow maintains it automatically.
+4. In GitHub's release editor, select **Publish this Action to the GitHub Marketplace**.
+5. Run the **Channel health** workflow and confirm the public sites resolve and Marketplace shows the release.
+
+The public installation examples use `codylabs/cody-code-reviewer@v1`, so patch
+and minor releases do not require copies of workflow YAML to be updated across
+the website and documentation.

--- a/README.md
+++ b/README.md
@@ -38,16 +38,19 @@ jobs:
       pull-requests: write
     steps:
       - name: Review pull request
-        uses: codylabs/cody-code-reviewer@v1.3.1
+        uses: codylabs/cody-code-reviewer@v1
         with:
           pr_number: ${{ github.event.pull_request.number }}
           repository: ${{ github.repository }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.6-sol
+          # To switch to Claude, replace the two lines above with:
+          # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # model: claude-opus-4-8
 ```
 
-For supply-chain-sensitive repositories, replace `v1.3.1` with the release's full commit SHA.
+For supply-chain-sensitive repositories, replace `v1` with the chosen release's full commit SHA.
 
 3. Commit the workflow, create a pull request, and watch Cody post its review.
 
@@ -60,7 +63,7 @@ Cody works with Anthropic's Claude models as well as OpenAI's. To review with Cl
 
 ```yaml
       - name: Review pull request
-        uses: codylabs/cody-code-reviewer@v1.3.1
+        uses: codylabs/cody-code-reviewer@v1
         with:
           pr_number: ${{ github.event.pull_request.number }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- restore provider-switching guidance without exposing an unused key
- use the maintained `v1` tag in installation examples
- automatically advance `v1` for future v1 releases
- document channel ownership and add scheduled public-channel health checks

This makes the GitHub README the canonical installation source for the docs, marketing site, Marketplace, and Gumroad channels.