### PR TITLE
Use the renamed Cody Marketplace URL

### DIFF
--- a/.github/workflows/channel-health.yml
+++ b/.github/workflows/channel-health.yml
@@ -20,7 +20,7 @@ jobs:
           set -euo pipefail
           for url in \
             "https://github.com/codylabs/cody-code-reviewer#installation" \
-            "https://github.com/marketplace/actions/cody-ai-code-reviewer-powered-by-openai" \
+            "https://github.com/marketplace/actions/cody-ai-code-reviewer" \
             "https://docs.codylabs.uk/" \
             "https://codylabs.uk/" \
             "https://codylabs.gumroad.com/l/cody-pro"; do
@@ -39,5 +39,5 @@ jobs:
             https://api.github.com/repos/codylabs/cody-code-reviewer/releases/latest \
             | python -c 'import json, sys; print(json.load(sys.stdin)["tag_name"])')"
           marketplace_page="$(curl --fail --location --retry 3 --connect-timeout 10 --max-time 60 --silent --show-error \
-            https://github.com/marketplace/actions/cody-ai-code-reviewer-powered-by-openai)"
+            https://github.com/marketplace/actions/cody-ai-code-reviewer)"
           grep --fixed-strings --quiet "$latest_release" <<< "$marketplace_page"

--- a/CHANNELS.md
+++ b/CHANNELS.md
@@ -7,7 +7,7 @@ product and link here instead of copying workflow YAML or model tables.
 | Channel | Canonical responsibility |
 | --- | --- |
 | [GitHub README](https://github.com/codylabs/cody-code-reviewer#installation) | Installation, provider selection, current inputs, and model examples |
-| [GitHub Marketplace](https://github.com/marketplace/actions/cody-ai-code-reviewer-powered-by-openai) | Discoverability and the latest published release |
+| [GitHub Marketplace](https://github.com/marketplace/actions/cody-ai-code-reviewer) | Discoverability and the latest published release |
 | [Cody documentation](https://docs.codylabs.uk/) | Product overview, privacy, and links to GitHub setup |
 | [Cody Labs marketing site](https://codylabs.uk/) | Short product positioning and links to GitHub, Marketplace, docs, and Gumroad |
 | [Cody Pro on Gumroad](https://codylabs.gumroad.com/l/cody-pro) | GitLab/Azure DevOps sales page; detailed setup ships with the product |


### PR DESCRIPTION
Updates channel documentation and health checks to the accurate Marketplace slug derived from the renamed action (`Cody AI Code Reviewer`). The old OpenAI-only listing slug now returns 404.