### PR TITLE
Default pr_number, repository and github_token from workflow context

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,17 @@ jobs:
       - name: Review pull request
         uses: codylabs/cody-code-reviewer@v1
         with:
-          pr_number: ${{ github.event.pull_request.number }}
-          repository: ${{ github.repository }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.6-luna
           # To switch to Claude, replace the two lines above with:
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # model: claude-opus-4-8
 ```
+
+The pull request number, repository and GitHub token are read from the workflow context
+automatically. Pass `pr_number`, `repository` or `github_token` explicitly only when you
+need to override them (for example, reviewing a different PR than the one that triggered
+the run).
 
 For supply-chain-sensitive repositories, replace `v1` with the chosen release's full commit SHA.
 
@@ -65,9 +67,6 @@ Cody works with Anthropic's Claude models as well as OpenAI's. To review with Cl
       - name: Review pull request
         uses: codylabs/cody-code-reviewer@v1
         with:
-          pr_number: ${{ github.event.pull_request.number }}
-          repository: ${{ github.repository }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: claude-opus-4-8
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ automatically. Pass `pr_number`, `repository` or `github_token` explicitly only 
 need to override them (for example, reviewing a different PR than the one that triggered
 the run).
 
+The job must grant the token `pull-requests: write` (as in the example above), or the
+review cannot be posted. Workflows triggered by pull requests from forks receive a
+read-only token; the example's `if` condition skips fork PRs for that reason, so keep it
+(or supply a `github_token` with write access) if you accept fork contributions.
+
 For supply-chain-sensitive repositories, replace `v1` with the chosen release's full commit SHA.
 
 3. Commit the workflow, create a pull request, and watch Cody post its review.

--- a/action.yml
+++ b/action.yml
@@ -1,15 +1,21 @@
 name: "Cody AI Code Reviewer"
 description: "Review pull requests with OpenAI or Anthropic Claude models"
 inputs:
+  # GitHub does not enforce `required` for composite-action inputs: a workflow that
+  # omits them gets empty strings, not an error. Every context-derivable input therefore
+  # defaults from the event so the minimal `uses:` workflow works out of the box.
   pr_number:
-    description: "Pull request number"
-    required: true
+    description: "Pull request number; defaults to the number of the PR that triggered the workflow"
+    required: false
+    default: ${{ github.event.pull_request.number }}
   repository:
-    description: "Repository name"
-    required: true
+    description: "Repository name; defaults to the repository running the workflow"
+    required: false
+    default: ${{ github.repository }}
   github_token:
-    description: "GitHub token used to read the pull request and post the review"
-    required: true
+    description: "GitHub token used to read the pull request and post the review; defaults to the workflow's token (needs pull-requests: write)"
+    required: false
+    default: ${{ github.token }}
   openai_api_key:
     description: "OpenAI API key; required when using an OpenAI model"
     required: false
@@ -23,6 +29,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Check pull request context
+      run: |
+        if [[ -z "$PR_NUMBER" ]]; then
+          echo "::error title=Cody needs a pull request::No pull request number available. Run this action on pull_request events, or pass the pr_number input explicitly."
+          exit 1
+        fi
+      shell: bash
+      env:
+        PR_NUMBER: ${{ inputs.pr_number }}
+
     - name: Set up Python 3.13
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:

--- a/action.yml
+++ b/action.yml
@@ -31,13 +31,25 @@ runs:
   steps:
     - name: Check pull request context
       run: |
+        failed=0
         if [[ -z "$PR_NUMBER" ]]; then
           echo "::error title=Cody needs a pull request::No pull request number available. Run this action on pull_request events, or pass the pr_number input explicitly."
-          exit 1
+          failed=1
         fi
+        if [[ -z "$REPOSITORY" ]]; then
+          echo "::error title=Cody needs a repository::The repository input resolved empty. Omit it to use the current repository, or pass owner/name explicitly."
+          failed=1
+        fi
+        if [[ -z "$GITHUB_TOKEN" ]]; then
+          echo "::error title=Cody needs a token::The github_token input resolved empty. Omit it to use the workflow token (with pull-requests: write), or pass one explicitly."
+          failed=1
+        fi
+        exit "$failed"
       shell: bash
       env:
         PR_NUMBER: ${{ inputs.pr_number }}
+        REPOSITORY: ${{ inputs.repository }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
 
     - name: Set up Python 3.13
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
## Defect

A customer workflow using the minimal form (only `openai_api_key` + `model`) crashes with `review_pull_request.py: error: argument pull_number: invalid int value: ''`. GitHub does not enforce `required: true` for composite-action inputs, so omitted inputs arrive as empty strings. Hit in production on daviddigital/solarsight PRs #1/#2 (2026-08-02).

## Fix

- `pr_number` defaults to `github.event.pull_request.number`, `repository` to `github.repository`, `github_token` to `github.token`: the minimal workflow now works out of the box.
- New first step fails fast with a clear `::error` when there is genuinely no PR context (non-PR event and no explicit input), instead of a cryptic argparse crash after a full Python setup.
- README examples simplified to the minimal form; explicit inputs documented as overrides.

## Verification

- pytest: 21 passed.
- After merge + v1 retag, the failed solarsight runs will be re-run to confirm reviews post with the minimal workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)