### PR TITLE
Pass MODEL to the comment step; bump own action pin to v1.5.0

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Review pull request
         # Pinned to a published release SHA: PR-controlled code must never run
         # with this job's secrets (Cody's own review flagged the uses: ./ form).
-        uses: codylabs/cody-code-reviewer@c5316225722a3cf6401e4436ae689138ba6bc053 # v1.3.1
+        uses: codylabs/cody-code-reviewer@984bc66bdf6b4a91d80b1d85899e13adedd72416 # v1.5.0
         with:
           pr_number: ${{ github.event.pull_request.number }}
           repository: ${{ github.repository }}

--- a/action.yml
+++ b/action.yml
@@ -93,6 +93,10 @@ runs:
       env:
         GITHUB_ACTION_PATH: ${{ github.action_path }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        # MODEL is needed here too: the posted header names the review model, and
+        # without it the comment step would stamp the default model regardless of
+        # which model actually produced the review.
+        MODEL: ${{ inputs.model }}
         PR_NUMBER: ${{ inputs.pr_number }}
         REPOSITORY: ${{ inputs.repository }}
         REVIEW_OUTPUT: ${{ runner.temp }}/cody-review-${{ github.run_id }}-${{ github.run_attempt }}.md


### PR DESCRIPTION
## Defects

1. The deterministic header (#24) names the review model, but the "Comment on Pull Request" step's env never included MODEL, so `config.MODEL` fell back to the default. Any customer setting a custom `model:` gets the wrong model stamped in the posted review.
2. Our own code_review.yml still pinned v1.3.1, predating #24 entirely, which is why reviews on this repo showed no model header at all.

## Fix

- Add MODEL to the comment step env (with a comment explaining why it is needed there).
- Bump the self-review workflow pin to the v1.5.0 release SHA.

pytest: 21 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)