### PR TITLE
Docs: SHA-pinned examples as the default

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Review pull request
         # Pinned to a published release SHA: PR-controlled code must never run
         # with this job's secrets (Cody's own review flagged the uses: ./ form).
-        uses: codylabs/cody-code-reviewer@984bc66bdf6b4a91d80b1d85899e13adedd72416 # v1.5.0
+        uses: codylabs/cody-code-reviewer@ef39a140710d8f2e6a0f9b69d3cda2a5f4626a06 # v1.5.1
         with:
           pr_number: ${{ github.event.pull_request.number }}
           repository: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Review pull request
-        uses: codylabs/cody-code-reviewer@v1
+        uses: codylabs/cody-code-reviewer@ef39a140710d8f2e6a0f9b69d3cda2a5f4626a06 # v1.5.1
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.6-luna
@@ -57,7 +57,12 @@ review cannot be posted. Workflows triggered by pull requests from forks receive
 read-only token; the example's `if` condition skips fork PRs for that reason, so keep it
 (or supply a `github_token` with write access) if you accept fork contributions.
 
-For supply-chain-sensitive repositories, replace `v1` with the chosen release's full commit SHA.
+The examples pin the action to a release's full commit SHA, which is the recommended way
+to use any third-party action: the code that reviews your pull requests can never change
+underneath you. New releases are announced on the
+[releases page](https://github.com/codylabs/cody-code-reviewer/releases); update the SHA
+(and its version comment) when you want to adopt one. Referencing the moving `v1` tag also
+works if you prefer automatic updates over supply-chain safety.
 
 3. Commit the workflow, create a pull request, and watch Cody post its review.
 
@@ -70,7 +75,7 @@ Cody works with Anthropic's Claude models as well as OpenAI's. To review with Cl
 
 ```yaml
       - name: Review pull request
-        uses: codylabs/cody-code-reviewer@v1
+        uses: codylabs/cody-code-reviewer@ef39a140710d8f2e6a0f9b69d3cda2a5f4626a06 # v1.5.1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: claude-opus-4-8

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,53 @@
+# Releasing Cody
+
+Checklist for every release of the GitHub Action, and the propagation surfaces that go
+stale silently when skipped. Added 2026-08-03 after the context-defaults incident: the
+minimal-workflow crash shipped for weeks because nothing tied releases to the places that
+describe or embed the action.
+
+## 1. Release the action (this repo)
+
+- [ ] PR merged to master with a Cody review on it (dogfooding is the first smoke test).
+- [ ] `python3 -m pytest` green.
+- [ ] `gh release create vX.Y.Z --target <sha>` with honest notes.
+- [ ] Move the `v1` tag: `git tag -f v1 <sha> && git push -f origin v1`.
+- [ ] Bump the SHA pin (`uses: codylabs/cody-code-reviewer@<sha> # vX.Y.Z`) in:
+  - [ ] This repo's own `.github/workflows/code_review.yml` (self-review dogfoods the new
+        release; it deliberately pins rather than tracking `v1` so PR-controlled code
+        cannot run in review context).
+  - [ ] README examples (both the OpenAI and Claude blocks). SHA pinning is the
+        documented default; `@v1` is mentioned only as the auto-update alternative.
+
+## 2. Docs and marketing surfaces
+
+- [ ] docs.codylabs.uk (repo `daviddigital/codylabs`, Docusaurus, auto-deploys on push to
+      master): the GitHub Actions tutorial blog post embeds a full workflow with the
+      pinned SHA; update it. `docs/intro.md` only links to the GitHub README, which is
+      why the README stays the single install source: keep it that way.
+- [ ] codylabs.uk (repo `~/projects/codylabs-portfolio`): links to the GitHub README, no
+      embedded snippet. Nothing to do unless a release changes the pitch (model support,
+      pricing). Deploy gate: `node business/check.mjs check`, push to main.
+
+## 3. Distributions that share the review engine (separate release trains)
+
+The GitLab and Azure DevOps products do NOT consume this action; behavior fixes here
+usually need porting there:
+
+- [ ] `codylabs/cody-pro` (GitLab MR + Azure DevOps scripts, Python, sold via Gumroad):
+      active branch is `feat/azure-marketplace-extension`, not main. Port prompt/header/
+      output-format changes; its customers install by script, so README + Gumroad listing
+      copy may also need the same doc updates.
+- [ ] `codylabs/cody-pro-azure-devops` (VS Marketplace extension, BYOL): port the same
+      changes; bump `vss-extension.json` AND `task.json` versions together (Marketplace
+      versions are immutable, roll forward, never re-upload); publishing to the
+      Marketplace is a separate manual step after merge.
+- [ ] Portfolio dogfooding repos (19 `daviddigital/*` + `codylabs/*` workflows) track
+      `@v1` DELIBERATELY so every release is exercised on real PRs immediately: do not
+      "fix" them to SHA pins; they are the canary, not a customer surface.
+
+## 4. Post-release verification
+
+- [ ] Open or re-run a review on a real PR in a repo using the MINIMAL workflow (no
+      pr_number/repository/github_token inputs) and confirm the review posts with the
+      correct model named in the header.
+- [ ] `codylabs/cody-github-smoke-canary` run green.


### PR DESCRIPTION
Per David: default customers to the secure form instead of an afterthought footnote. README examples (and our own self-review workflow) now pin `ef39a14 # v1.5.1`; the supply-chain note explains why and mentions `@v1` as the opt-in convenience instead of the other way round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)