### PR TITLE
Remediate the open Python dependency alerts

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -594,13 +594,13 @@ pynacl==1.6.2 \
     --hash=sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2 \
     --hash=sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9
     # via pygithub
-pytest==8.4.2 \
-    --hash=sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01 \
-    --hash=sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79
+pytest==9.0.3 \
+    --hash=sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9 \
+    --hash=sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c
     # via -r requirements-dev.txt
-python-dotenv==1.2.1 \
-    --hash=sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6 \
-    --hash=sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61
+python-dotenv==1.2.2 \
+    --hash=sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a \
+    --hash=sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3
     # via -r requirements.txt
 requests==2.34.2 \
     --hash=sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0 \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 -r requirements.txt
-pytest==8.4.2
+pytest==9.0.3

--- a/requirements.lock
+++ b/requirements.lock
@@ -578,9 +578,9 @@ pynacl==1.6.2 \
     --hash=sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2 \
     --hash=sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9
     # via pygithub
-python-dotenv==1.2.1 \
-    --hash=sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6 \
-    --hash=sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61
+python-dotenv==1.2.2 \
+    --hash=sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a \
+    --hash=sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3
     # via -r requirements.txt
 requests==2.34.2 \
     --hash=sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 anthropic==0.117.0
 openai==2.46.0
 PyGithub==2.9.1
-python-dotenv==1.2.1
+python-dotenv==1.2.2


### PR DESCRIPTION
## What changes

- Bumps `python-dotenv` from 1.2.1 to 1.2.2 in runtime and development inputs
- Bumps `pytest` from 8.4.2 to 9.0.3
- Regenerates both hash-locked dependency files with the repository's documented Python 3.13 `uv pip compile` commands

## Why a separate PR

These versions remediate the three currently open medium-severity Dependabot alerts. Keeping dependency remediation separate from #29 makes both reviews smaller and lets another model assess supply-chain changes independently. It also supersedes the incomplete Dependabot PRs #18 and #19, which changed only the input files and therefore failed the lock-consistency CI gate.

## Verification

- Lock files regenerated with `uv 0.12.1` and `--python-version 3.13 --generate-hashes --no-header`
- Existing suite passes locally on the workspace Python: 20 passed, 1 integration test deselected
- GitHub CI is the authoritative Python 3.13 installation and pytest 9 compatibility check
- `git diff --check` clean

This PR is intentionally left unmerged for cross-model review.