### PR TITLE
Bump the SHA pin to v1.6.0

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Review pull request
         # Pinned to a published release SHA: PR-controlled code must never run
         # with this job's secrets (Cody's own review flagged the uses: ./ form).
-        uses: codylabs/cody-code-reviewer@ef39a140710d8f2e6a0f9b69d3cda2a5f4626a06 # v1.5.1
+        uses: codylabs/cody-code-reviewer@b44126ce4a0de75f449281504b1226d94205ecb9 # v1.6.0
         with:
           pr_number: ${{ github.event.pull_request.number }}
           repository: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Review pull request
-        uses: codylabs/cody-code-reviewer@ef39a140710d8f2e6a0f9b69d3cda2a5f4626a06 # v1.5.1
+        uses: codylabs/cody-code-reviewer@b44126ce4a0de75f449281504b1226d94205ecb9 # v1.6.0
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.6-luna
@@ -75,7 +75,7 @@ Cody works with Anthropic's Claude models as well as OpenAI's. To review with Cl
 
 ```yaml
       - name: Review pull request
-        uses: codylabs/cody-code-reviewer@ef39a140710d8f2e6a0f9b69d3cda2a5f4626a06 # v1.5.1
+        uses: codylabs/cody-code-reviewer@b44126ce4a0de75f449281504b1226d94205ecb9 # v1.6.0
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: claude-opus-4-8
@@ -100,7 +100,7 @@ it can run for hours. Set `max_review_rounds` to stop it after a fixed number of
 
 ```yaml
       - name: Review pull request
-        uses: codylabs/cody-code-reviewer@ef39a140710d8f2e6a0f9b69d3cda2a5f4626a06 # v1.5.1
+        uses: codylabs/cody-code-reviewer@b44126ce4a0de75f449281504b1226d94205ecb9 # v1.6.0
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           model: gpt-5.6-luna


### PR DESCRIPTION
Follows the same pattern as the v1.5.0 to v1.5.1 bump (PR #27): this repo's own dogfood workflow (.github/workflows/code_review.yml) pins to a release SHA rather than tracking v1 (so PR-controlled code can never run with this job's secrets), and the README examples are SHA-pinned by policy. Both go stale the moment a new release ships, so this is the standard follow-up bump for v1.6.0.

- .github/workflows/code_review.yml: bumped to b44126ce4a0de75f449281504b1226d94205ecb9 # v1.6.0
- README.md: all three uses: examples (the OpenAI block, the Claude block, and the max_review_rounds example) bumped to the same SHA